### PR TITLE
스케줄 - 단 건 조회 (수정으로 이어질 예정), 삭제 화면, 직원 등록 화면 구현

### DIFF
--- a/wizbuddy_front/src/assets/css/schedule/DeletePage.css
+++ b/wizbuddy_front/src/assets/css/schedule/DeletePage.css
@@ -3,7 +3,7 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: flex-start;
-    min-height: calc(100vh - 151.6px);
+    min-height: 100vh;
     padding-bottom: 41.6px;
     background-color: #F3F7FA;
     padding: 0 20px;
@@ -46,7 +46,7 @@
   }
 
 .calendar-container {
-    max-width: 850px;
+    max-width: 900px;
     width: 100%;
     margin-top: 20px;
     background-color: white;
@@ -69,21 +69,18 @@
     font-weight: bold;
     position: relative;
     margin-bottom: 5px;
-    margin-left: 200px;
-    margin-right: 200px;
+    margin-left: 190px;
+    margin-right: 190px;
 }
 
 .calendar-header h2 {
     font-size: auto;
-    margin-bottom: 10px;
-    padding-left: 30px;
-    padding-right: 30px;
 }
 
 /* 이전, 다음 버튼 스타일 */
 .prev-next-button {
     font-size: 18px;
-    padding: 5px 10px;
+    margin-top: 5px;
     cursor: pointer;
     border: none;
     background-color: transparent;
@@ -117,15 +114,14 @@
     grid-template-columns: repeat(7, 1fr);
     text-align: center;
     font-weight: bold;
-    margin-bottom: 10px;
 }
 
 /* 날짜 셀 */
 .calendar-days {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    grid-auto-rows: minmax(70px, auto);
-    gap: 10px;
+    grid-auto-rows: minmax(100px, auto);
+    gap: 5px;
 }
 
 .calendar-day {
@@ -140,7 +136,6 @@
     align-items: center;
 }
 
-/* 날짜 번호 스타일 */
 .calendar-day .day-number {
     font-size: 10px;
     font-weight: bold;
@@ -151,7 +146,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 5px;
     background-color: transparent;
 }
 
@@ -172,34 +166,61 @@
     width: 100%;
 }
 
-/* 스케줄 스타일 */
 .schedule {
     padding: 5px;
     border-radius: 5px;
     margin: 2px 0;
-    font-size: 8px;
     text-align: center;
+    cursor: pointer;
 }
 
-/* 스케줄 타입별 스타일 */
+.schedule:hover {
+    background-color: #e0e0e0;
+}
+
+.schedule-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 5px;
+    background-color: #f3f7fa;
+    border-radius: 8px;
+    margin-bottom: 8px;
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.schedule-group .schedule-group-header {
+    font-weight: bold;
+    color: #333;
+    margin-bottom: 5px;
+}
+
+.schedule-group .schedule-names {
+    font-size: 12px;
+    text-align: center;
+    color: #555;
+}
+
 .schedule.fun {
+    font-size: 9px;
     background-color: #D2F0FF;
 }
 
 .schedule.important {
+    font-size: 9px;
     background-color: #FFD9D9;
 }
 
 .schedule.personal {
+    font-size: 9px;
     background-color: #FEE6C9;
 }
 
-/* 날짜 셀 hover 효과 */
 .calendar-day:hover {
     background-color: #f44336;
 }
 
-/* 빈 날짜 */
 .calendar-day.blank {
     visibility: hidden;
 }
@@ -208,4 +229,50 @@
     width: 20%; 
     background-color: #F3F7FA;
     padding: 20px;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-container {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 10px;
+    width: 450px;
+    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.modal-title {
+    font-size: 20px;
+    font-weight: bold;
+}
+
+.close-btn {
+    background-color: transparent;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+.schedule-item {
+    margin-bottom: 10px;
+    display: flex;
+    justify-content: space-between;
 }

--- a/wizbuddy_front/src/assets/css/schedule/FindAllSchedules.css
+++ b/wizbuddy_front/src/assets/css/schedule/FindAllSchedules.css
@@ -3,7 +3,7 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: flex-start;
-    min-height: calc(100vh - 151.6px);
+    min-height: 100vh;
     padding-bottom: 41.6px;
     background-color: #F3F7FA;
     padding: 0 20px;
@@ -20,7 +20,7 @@
 }
 
   .schedule-container {
-    max-width: 850px;
+    max-width: 900px;
     width: 100%;
     margin-top: 20px;
     background-color: white;
@@ -39,8 +39,8 @@
     align-items: center;
     margin-top: 10px;
     margin-bottom: 20px;
-    margin-left: 180px;
-    margin-right: 180px;
+    margin-left: 120px;
+    margin-right: 120px;
   }
   
   .date-range {
@@ -106,6 +106,9 @@
   }
   
   .prev-next-button {
+    padding-left: 20px;
+    padding-right: 20px;
+    margin-top: 5px;
     cursor: pointer;
     background: none;
     border: none;

--- a/wizbuddy_front/src/assets/css/schedule/Main.css
+++ b/wizbuddy_front/src/assets/css/schedule/Main.css
@@ -10,10 +10,10 @@
 }
 
 .left-side {
-    width: 16%; 
+    width: 16%;
     background-color: #F3F7FA;
     padding: 20px;
-    margin-left : 20px;
+    margin-left: 20px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -27,9 +27,9 @@
     justify-content: center;
     width: 100%;
     background: #f3f7fa;
-  }
-  
-  .side-tab-item {
+}
+
+.side-tab-item {
     display: block;
     padding: 10px 10px;
     font-size: 16px;
@@ -39,14 +39,14 @@
     border-radius: 30px;
     margin-bottom: 20px;
     cursor: pointer;
-  }
-  
-  .side-tab-item:hover {
+}
+
+.side-tab-item:hover {
     background-color: #f0f0f0;
-  }
+}
 
 .calendar-container {
-    max-width: 850px;
+    max-width: 900px;
     width: 100%;
     margin-top: 20px;
     background-color: white;
@@ -59,9 +59,8 @@
     flex: 1;
 }
 
-/* 달력의 헤더 부분 */
 .calendar-header {
-    display:flex;
+    display: flex;
     justify-content: center;
     align-items: center;
     padding: 8px 5px;
@@ -69,21 +68,17 @@
     font-weight: bold;
     position: relative;
     margin-bottom: 5px;
-    margin-left: 200px;
-    margin-right: 200px;
+    margin-left: 190px;
+    margin-right: 190px;
 }
 
 .calendar-header h2 {
     font-size: auto;
-    padding-left: 30px;
-    padding-right: 30px;
 }
 
-/* 이전, 다음 버튼 스타일 */
 .prev-next-button {
     font-size: 18px;
     margin-top: 5px;
-    padding: 5px 10px;
     cursor: pointer;
     border: none;
     background-color: transparent;
@@ -105,13 +100,11 @@
     border-radius: 5px;
 }
 
-/* 달력 본문 */
 .calendar-body {
     display: flex;
     flex-direction: column;
 }
 
-/* 요일 제목 */
 .calendar-weekdays {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
@@ -119,7 +112,6 @@
     font-weight: bold;
 }
 
-/* 날짜 셀 */
 .calendar-days {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
@@ -139,7 +131,6 @@
     align-items: center;
 }
 
-/* 날짜 번호 스타일 */
 .calendar-day .day-number {
     font-size: 10px;
     font-weight: bold;
@@ -153,57 +144,128 @@
     background-color: transparent;
 }
 
-/* 선택된 날짜 */
 .calendar-day.selected {
     background-color: #fffcd5;
 }
 
-/* 오늘 날짜 */
 .calendar-day.today .day-number {
     background-color: #000000;
     color: white;
 }
 
-/* 스케줄 영역 */
 .calendar-day .schedules {
     margin-top: 5px;
     width: 100%;
 }
 
-/* 스케줄 스타일 */
 .schedule {
     padding: 5px;
     border-radius: 5px;
     margin: 2px 0;
-    font-size: 8px;
+    font-size: 10px;
     text-align: center;
+    cursor: pointer;
 }
 
-/* 스케줄 타입별 스타일 */
+.schedule:hover {
+    background-color: #e0e0e0;
+}
+
+.schedule-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 5px;
+    background-color: #f3f7fa;
+    border-radius: 8px;
+    margin-bottom: 8px;
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.schedule-group .schedule-group-header {
+    font-weight: bold;
+    color: #333;
+    margin-bottom: 5px;
+}
+
+.schedule-group .schedule-names {
+    font-size: 12px;
+    text-align: center;
+    color: #555;
+}
+
 .schedule.fun {
+    font-size: 9px;
     background-color: #D2F0FF;
 }
 
 .schedule.important {
+    font-size: 9px;
     background-color: #FFD9D9;
 }
 
 .schedule.personal {
+    font-size: 9px;
     background-color: #FEE6C9;
 }
 
-/* 날짜 셀 hover 효과 */
 .calendar-day:hover {
     background-color: #e0e0e0;
 }
 
-/* 빈 날짜 */
 .calendar-day.blank {
     visibility: hidden;
 }
 
 .right-side {
-    width: 20%; 
+    width: 20%;
     background-color: #F3F7FA;
     padding: 20px;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-container {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 10px;
+    width: 450px;
+    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.modal-title {
+    font-size: 20px;
+    font-weight: bold;
+}
+
+.close-btn {
+    background-color: transparent;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+.schedule-item {
+    margin-bottom: 10px;
+    display: flex;
+    justify-content: space-between;
 }

--- a/wizbuddy_front/src/assets/css/schedule/Main.css
+++ b/wizbuddy_front/src/assets/css/schedule/Main.css
@@ -3,7 +3,7 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: flex-start;
-    min-height: calc(100vh - 151.6px);
+    min-height: 100vh;
     padding-bottom: 41.6px;
     background-color: #F3F7FA;
     padding: 0 20px;
@@ -75,7 +75,6 @@
 
 .calendar-header h2 {
     font-size: auto;
-    margin-bottom: 10px;
     padding-left: 30px;
     padding-right: 30px;
 }
@@ -83,6 +82,7 @@
 /* 이전, 다음 버튼 스타일 */
 .prev-next-button {
     font-size: 18px;
+    margin-top: 5px;
     padding: 5px 10px;
     cursor: pointer;
     border: none;
@@ -117,15 +117,14 @@
     grid-template-columns: repeat(7, 1fr);
     text-align: center;
     font-weight: bold;
-    margin-bottom: 10px;
 }
 
 /* 날짜 셀 */
 .calendar-days {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    grid-auto-rows: minmax(70px, auto);
-    gap: 10px;
+    grid-auto-rows: minmax(100px, auto);
+    gap: 5px;
 }
 
 .calendar-day {
@@ -151,7 +150,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 5px;
     background-color: transparent;
 }
 

--- a/wizbuddy_front/src/assets/css/schedule/ScheduleRegisterPage.css
+++ b/wizbuddy_front/src/assets/css/schedule/ScheduleRegisterPage.css
@@ -3,7 +3,7 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: flex-start;
-    min-height: calc(100vh - 151.6px);
+    min-height: 100vh;
     padding-bottom: 41.6px;
     background-color: #F3F7FA;
     padding: 0 20px;
@@ -46,7 +46,7 @@
   }
 
 .calendar-container {
-    max-width: 850px;
+    max-width: 900px;
     width: 100%;
     margin-top: 20px;
     background-color: white;
@@ -59,7 +59,6 @@
     flex: 1;
 }
 
-/* 달력의 헤더 부분 */
 .calendar-header {
     display:flex;
     justify-content: center;
@@ -69,21 +68,17 @@
     font-weight: bold;
     position: relative;
     margin-bottom: 5px;
-    margin-left: 200px;
-    margin-right: 200px;
+    margin-left: 190px;
+    margin-right: 190px;
 }
 
 .calendar-header h2 {
     font-size: auto;
-    margin-bottom: 10px;
-    padding-left: 30px;
-    padding-right: 30px;
 }
 
-/* 이전, 다음 버튼 스타일 */
 .prev-next-button {
     font-size: 18px;
-    padding: 5px 10px;
+    margin-top: 5px;
     cursor: pointer;
     border: none;
     background-color: transparent;
@@ -105,27 +100,23 @@
     border-radius: 5px;
 }
 
-/* 달력 본문 */
 .calendar-body {
     display: flex;
     flex-direction: column;
 }
 
-/* 요일 제목 */
 .calendar-weekdays {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
     text-align: center;
     font-weight: bold;
-    margin-bottom: 10px;
 }
 
-/* 날짜 셀 */
 .calendar-days {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    grid-auto-rows: minmax(70px, auto);
-    gap: 10px;
+    grid-auto-rows: minmax(100px, auto);
+    gap: 5px;
 }
 
 .calendar-day {
@@ -151,7 +142,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 5px;
     background-color: transparent;
 }
 
@@ -177,20 +167,23 @@
     padding: 5px;
     border-radius: 5px;
     margin: 2px 0;
-    font-size: 8px;
+    font-size: 10px;
     text-align: center;
 }
 
 /* 스케줄 타입별 스타일 */
 .schedule.fun {
+    font-size: 9px;
     background-color: #D2F0FF;
 }
 
 .schedule.important {
+    font-size: 9px;
     background-color: #FFD9D9;
 }
 
 .schedule.personal {
+    font-size: 9px;
     background-color: #FEE6C9;
 }
 

--- a/wizbuddy_front/src/components/schedule/DeletePage.vue
+++ b/wizbuddy_front/src/components/schedule/DeletePage.vue
@@ -1,168 +1,212 @@
 <template>
     <div class="main-container">
-        <aside class="left-side">
-            <ScheduleTab/>
-            <div class="side">
-                <EmployerSideMenu/>
-            </div>
-        </aside>
-
-        <div class="calendar-container">
-            <div class="calendar-header">
-                <button @click="prevMonth" class="prev-next-button">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-                    </svg>
-                </button>
-                <h2>{{ currentYear }}년 {{ months[currentMonth] }} 스케줄 </h2>
-                <button @click="nextMonth" class="prev-next-button">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                    </svg>
-                </button>
-            </div>
-    
-            <div class="calendar-body">
-                <div class="calendar-weekdays">
-                    <div v-for="day in weekdays" :key="day" class="weekday">{{ day }}</div>
-                </div>
-                <div class="calendar-days">
-                    <div
-                        v-for="day in daysInMonth"
-                        :key="day"
-                        class="calendar-day"
-                        :class="{ today: isToday(day), selected: day === selectedDay }"
-                        @click="selectDay(day)">
-                        <div class="day-number">{{ day }}</div>
-                        <div class="schedules">
-                            <div
-                                v-for="(schedule, index) in getSchedulesForDay(day)"
-                                :key="index"
-                                :class="['schedule', schedule.type]">
-                                {{ schedule.title }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+      <aside class="left-side">
+        <ScheduleTab />
+        <div class="side">
+          <EmployerSideMenu />
         </div>
-        <aside class="right-side">
-            <UserProfileMenu/>
-        </aside>
-
-        <DeleteModal
-          v-if="isDeleteModalOpen"
-          :isOpen="isDeleteModalOpen"
-          :selectedDate="selectedDay"
-          @close="closeDeleteModal"
-          @submit="handleEmployeeDelete"
-        />
+      </aside>
+  
+      <div class="calendar-container">
+        <div class="calendar-header">
+          <button @click="prevMonth" class="prev-next-button">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <h2>{{ currentYear }}년 {{ months[currentMonth] }} 스케줄</h2>
+          <button @click="nextMonth" class="prev-next-button">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+  
+        <div class="calendar-body">
+          <div class="calendar-weekdays">
+            <div v-for="day in weekdays" :key="day" class="weekday">{{ day }}</div>
+          </div>
+          <div class="calendar-days">
+            <div v-for="(blank, index) in blanks" :key="index" class="calendar-day blank"></div>
+            <div
+              v-for="day in daysInMonth"
+              :key="day"
+              class="calendar-day"
+              :class="{ today: isToday(day), selected: day === selectedDay }"
+            >
+              <div class="day-number">{{ day }}</div>
+              <div class="schedules">
+                <div
+                  v-for="(group, type) in groupSchedulesByType(day)"
+                  :key="type"
+                  :class="['schedule', group.type]"
+                  @click="selectSchedule(day, group)"
+                >
+                  {{ group.names.join(', ') }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+  
+      <ScheduleInfoModalForDelete
+        v-if="isScheduleModalOpen"
+        :isOpen="isScheduleModalOpen"
+        :selectedDate="selectedDay"
+        :schedules="selectedSchedules"
+        :currentMonth="months[currentMonth]"
+        @close="closeScheduleModal"
+        @deleteRequest="openDeleteModalAfterClosingSchedule"
+      />
+  
+      <aside class="right-side">
+        <UserProfileMenu />
+      </aside>
+  
+      <!-- 삭제 모달 -->
+      <DeleteModal
+        v-if="isDeleteModalOpen"
+        :isOpen="isDeleteModalOpen"
+        @close="closeDeleteModal"
+        @confirmDelete="handleDeleteConfirmation"
+      />
     </div>
-</template>
-
-<script setup>
-    import { ref } from 'vue';
-    import ScheduleTab from './ScheduleTab.vue';
-    import UserProfileMenu from '../UserProfileMenu.vue';
-    import EmployerSideMenu from './EmployerSideMenu.vue';
-    import DeleteModal from './modal/DeleteModal.vue';
-
-    const selectedDay = ref(null);
-    const currentDate = ref(new Date());
-    const currentMonth = ref(currentDate.value.getMonth());
-    const currentYear = ref(currentDate.value.getFullYear());
-    
-    const today = ref(new Date());
-
-    // 모달 상태 관리 변수
-    const isDeleteModalOpen = ref(false);  // 초기값 추가
-    
-    const months = [
-      '1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월'
-    ];
-    
-    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
-    
-    // 스케줄 데이터 예시
-    const scheduleData = [
-      { day: 15, title: '유제은, 백경석, 조제훈', type: 'fun' },
-      { day: 15, title: '이서현', type: 'important' },
-      { day: 15, title: '이나현', type: 'personal' },
-    ];
-    
-    const getSchedulesForDay = (day) => {
-      return scheduleData.filter(schedule => schedule.day === day).slice(0, 2); // 최대 2개의 항목만 반환
-    };
-    
-    const getFirstDayOfMonth = (year, month) => new Date(year, month, 1);
-    const getLastDayOfMonth = (year, month) => new Date(year, month + 1, 0);
-    
-    const blanks = ref([]);
-    const daysInMonth = ref([]);
-    
-    const updateCalendar = () => {
-      const firstDay = getFirstDayOfMonth(currentYear.value, currentMonth.value);
-      const lastDay = getLastDayOfMonth(currentYear.value, currentMonth.value);
-    
-      const numBlanks = firstDay.getDay();
-      blanks.value = Array(numBlanks).fill(null);
-    
-      const daysArray = [];
-      for (let day = 1; day <= lastDay.getDate(); day++) {
-        daysArray.push(day);
-      }
-      daysInMonth.value = daysArray;
-    };
-    
-    const isToday = (day) => {
-      return (
-        currentYear.value === today.value.getFullYear() &&
-        currentMonth.value === today.value.getMonth() &&
-        day === today.value.getDate()
-      );
-    };
-    
-    const prevMonth = () => {
-      currentMonth.value--;
-      if (currentMonth.value < 0) {
-        currentMonth.value = 11;
-        currentYear.value--;
-      }
-      updateCalendar();
-    };
-    
-    const nextMonth = () => {
-      currentMonth.value++;
-      if (currentMonth.value > 11) {
-        currentMonth.value = 0;
-        currentYear.value++;
-      }
-      updateCalendar();
-    };
-    
-    const selectDay = (day) => {
-      selectedDay.value = day;
-      openDeleteModal(); // 모달을 엽니다.
-    };
-
-    function openDeleteModal() {
-      isDeleteModalOpen.value = true;
+  </template>
+  
+  <script setup>
+  import { ref } from 'vue';
+  import ScheduleTab from './ScheduleTab.vue';
+  import UserProfileMenu from '../UserProfileMenu.vue';
+  import EmployerSideMenu from './EmployerSideMenu.vue';
+  import ScheduleInfoModalForDelete from '../schedule/modal/ScheduleInfoModalForDelete.vue';
+  import DeleteModal from './modal/DeleteModal.vue';
+  
+  const selectedDay = ref(null);
+  const currentDate = ref(new Date());
+  const currentMonth = ref(currentDate.value.getMonth());
+  const currentYear = ref(currentDate.value.getFullYear());
+  
+  const selectedSchedules = ref([]);
+  const isScheduleModalOpen = ref(false);
+  const isDeleteModalOpen = ref(false);
+  const today = ref(new Date());
+  
+  const months = [
+    '1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월',
+  ];
+  
+  const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+  
+  const scheduleData = [
+    { day: 15, title: '유제은', type: 'fun', time: '1T (09:00 ~ 14:00)' },
+    { day: 15, title: '백경석', type: 'fun', time: '1T (09:00 ~ 14:00)' },
+    { day: 15, title: '조제훈', type: 'fun', time: '1T (09:00 ~ 14:00)' },
+    { day: 15, title: '이서현', type: 'important', time: '2T (14:00 ~ 17:00)' },
+    { day: 15, title: '이나현', type: 'personal', time: '3T (17:00 ~ 21:00)' },
+  ];
+  
+  const getFirstDayOfMonth = (year, month) => new Date(year, month, 1);
+  const getLastDayOfMonth = (year, month) => new Date(year, month + 1, 0);
+  
+  const blanks = ref([]);
+  const daysInMonth = ref([]);
+  
+  const updateCalendar = () => {
+    const firstDay = getFirstDayOfMonth(currentYear.value, currentMonth.value);
+    const lastDay = getLastDayOfMonth(currentYear.value, currentMonth.value);
+  
+    const numBlanks = firstDay.getDay();
+    blanks.value = Array(numBlanks).fill(null);
+  
+    const daysArray = [];
+    for (let day = 1; day <= lastDay.getDate(); day++) {
+      daysArray.push(day);
     }
-
-    function closeDeleteModal() {
-      isDeleteModalOpen.value = false;
+    daysInMonth.value = daysArray;
+  };
+  
+  const isToday = (day) => {
+    return (
+      currentYear.value === today.value.getFullYear() &&
+      currentMonth.value === today.value.getMonth() &&
+      day === today.value.getDate()
+    );
+  };
+  
+  const prevMonth = () => {
+    currentMonth.value--;
+    if (currentMonth.value < 0) {
+      currentMonth.value = 11;
+      currentYear.value--;
     }
-
-    function handleEmployeeDelete() {
-      // 삭제 로직 수행 (필요 시 서버 API 호출)
-      console.log('직원 삭제 완료');
-      closeDeleteModal();
-    }
-
     updateCalendar();
-</script>
-
-
-<style scoped>
-  @import url('@/assets/css/schedule/DeletePage.css');
-</style>
+  };
+  
+  const nextMonth = () => {
+    currentMonth.value++;
+    if (currentMonth.value > 11) {
+      currentMonth.value = 0;
+      currentYear.value++;
+    }
+    updateCalendar();
+  };
+  
+  const groupSchedulesByType = (day) => {
+    const daySchedules = getSchedulesForDay(day);
+    const groupedSchedules = {};
+  
+    daySchedules.forEach((schedule) => {
+      if (!groupedSchedules[schedule.type]) {
+        groupedSchedules[schedule.type] = {
+          type: schedule.type,
+          time: schedule.time,
+          names: [],
+        };
+      }
+      groupedSchedules[schedule.type].names.push(schedule.title);
+    });
+  
+    return Object.values(groupedSchedules);
+  };
+  
+  const getSchedulesForDay = (day) => {
+    return scheduleData.filter((schedule) => schedule.day === day);
+  };
+  
+  const selectSchedule = (day, scheduleGroup) => {
+    selectedSchedules.value = scheduleGroup.names.map((name) => ({
+      title: name,
+      time: scheduleGroup.time,
+      type: scheduleGroup.type,
+    }));
+    selectedDay.value = day;
+    isScheduleModalOpen.value = true;
+  };
+  
+  const closeScheduleModal = () => {
+    isScheduleModalOpen.value = false;
+  };
+  
+  const openDeleteModalAfterClosingSchedule = () => {
+    closeScheduleModal();
+    isDeleteModalOpen.value = true;
+  };
+  
+  const closeDeleteModal = () => {
+    isDeleteModalOpen.value = false;
+  };
+  
+  const handleDeleteConfirmation = () => {
+    setTimeout(() => {
+      closeDeleteModal();
+    }, 5000);
+  };
+  
+  updateCalendar();
+  </script>
+  
+  <style scoped>
+    @import url('@/assets/css/schedule/DeletePage.css');
+  </style>
+  

--- a/wizbuddy_front/src/components/schedule/Main.vue
+++ b/wizbuddy_front/src/components/schedule/Main.vue
@@ -35,7 +35,6 @@
         </div>
         <div class="calendar-days">
           <div v-for="(blank, index) in blanks" :key="index" class="calendar-day blank"></div>
-          
           <div 
             v-for="day in daysInMonth"
             :key="day"
@@ -53,6 +52,14 @@
         </div>
       </div>
     </div>
+    <ScheduleInfoModal 
+      v-if="isScheduleModalOpen"
+      :isOpen="isScheduleModalOpen"
+      :selectedDate="selectedDay"
+      :schedules="selectedSchedules"
+      :currentMonth="months[currentMonth]"
+      @close="closeScheduleModal"
+    />
     <aside class="right-side">
       <UserProfileMenu/>
     </aside>
@@ -64,10 +71,14 @@
   import ScheduleTab from './ScheduleTab.vue';
   import UserProfileMenu from '../UserProfileMenu.vue';
   import EmployerSideMenu from './EmployerSideMenu.vue';
+  import ScheduleInfoModal from '../schedule/modal/ScheduleInfoModal.vue'
 
   const currentDate = ref(new Date());
   const currentMonth = ref(currentDate.value.getMonth());
   const currentYear = ref(currentDate.value.getFullYear());
+
+  const selectedSchedules = ref([]);
+  const isScheduleModalOpen = ref(false);
   
   const today = ref(new Date());
   
@@ -86,11 +97,6 @@
     { day: 15, title: '이나현', type: 'personal' },
     // 다른 스케줄 데이터 추가 가능
   ];
-  
-  // 특정 날짜의 스케줄을 가져오는 함수
-  const getSchedulesForDay = (day) => {
-    return scheduleData.filter(schedule => schedule.day === day).slice(0, 2); // 최대 2개의 항목만 반환
-  };
   
   // 특정 달의 첫 번째 날과 마지막 날 계산
   const getFirstDayOfMonth = (year, month) => new Date(year, month, 1);
@@ -150,11 +156,19 @@
     updateCalendar();
   };
   
-  // 날짜 선택 함수
-  const selectDay = (day) => {
-    selectedDay.value = day;
-    console.log('선택한 날짜:', `${currentYear.value}-${currentMonth.value + 1}-${day}`);
-  };
+  const getSchedulesForDay = (day) => {
+  return scheduleData.filter(schedule => schedule.day === day);
+};
+
+const selectDay = (day) => {
+  selectedDay.value = day;
+  selectedSchedules.value = getSchedulesForDay(day);
+  isScheduleModalOpen.value = true;
+};
+
+const closeScheduleModal = () => {
+  isScheduleModalOpen.value = false;
+};
   
   // 초기 달력 데이터 업데이트
   updateCalendar();

--- a/wizbuddy_front/src/components/schedule/RegisterPage.vue
+++ b/wizbuddy_front/src/components/schedule/RegisterPage.vue
@@ -36,10 +36,10 @@
                         <div class="day-number">{{ day }}</div>
                         <div class="schedules">
                             <div
-                                v-for="(schedule, index) in getSchedulesForDay(day)"
+                                v-for="(group, index) in groupSchedulesByType(day)"
                                 :key="index"
-                                :class="['schedule', schedule.type]">
-                                {{ schedule.title }}
+                                :class="['schedule', group.type]">
+                                {{ group.names.join(', ') }}
                             </div>
                         </div>
                     </div>
@@ -86,13 +86,32 @@
     
     // 스케줄 데이터 예시
     const scheduleData = [
-      { day: 15, title: '유제은, 백경석, 조제훈', type: 'fun' },
-      { day: 15, title: '이서현', type: 'important' },
-      { day: 15, title: '이나현', type: 'personal' },
+    { day: 15, title: '유제은', type: 'fun', time: '1T (09:00 ~ 14:00)' },
+    { day: 15, title: '백경석', type: 'fun', time: '1T (09:00 ~ 14:00)' },
+    { day: 15, title: '조제훈', type: 'fun', time: '1T (09:00 ~ 14:00)' },
+    { day: 15, title: '이서현', type: 'important', time: '2T (14:00 ~ 17:00)' },
+    { day: 15, title: '이나현', type: 'personal', time: '3T (17:00 ~ 21:00)' },
     ];
     
+    const groupSchedulesByType = (day) => {
+    const daySchedules = getSchedulesForDay(day);
+    const groupedSchedules = {};
+
+    daySchedules.forEach((schedule) => {
+        if (!groupedSchedules[schedule.type]) {
+            groupedSchedules[schedule.type] = {
+                type: schedule.type,
+                time: schedule.time,
+                names: []
+            };
+        }
+        groupedSchedules[schedule.type].names.push(schedule.title);
+      });
+      return Object.values(groupedSchedules);
+    };
+
     const getSchedulesForDay = (day) => {
-      return scheduleData.filter(schedule => schedule.day === day).slice(0, 2); // 최대 2개의 항목만 반환
+        return scheduleData.filter(schedule => schedule.day === day);
     };
     
     const getFirstDayOfMonth = (year, month) => new Date(year, month, 1);
@@ -143,7 +162,7 @@
     
     const selectDay = (day) => {
       selectedDay.value = day;
-      openRegisterModal(); // 날짜를 선택하면 모달을 엽니다.
+      openRegisterModal();
     };
 
     function openRegisterModal() {

--- a/wizbuddy_front/src/components/schedule/modal/DeleteModal.vue
+++ b/wizbuddy_front/src/components/schedule/modal/DeleteModal.vue
@@ -1,17 +1,22 @@
 <template>
     <div v-if="isOpen" class="modal-overlay" @click.self="closeModal">
       <div class="modal-container">
+        <!-- "삭제되었습니다" 메시지와 "정말 삭제하시겠습니까?" 메시지 구분 -->
         <h3 class="modal-title">{{ isDeleted ? '삭제되었습니다' : '정말 삭제하시겠습니까?' }}</h3>
+  
+        <!-- 삭제가 완료되지 않은 경우의 버튼 -->
         <div class="modal-actions" v-if="!isDeleted">
           <button type="button" class="cancel-btn" @click="closeModal">아니오</button>
           <button type="button" class="delete-btn" @click="confirmDelete">네</button>
         </div>
+  
+        <!-- 삭제 완료 후 "확인" 버튼만 보이도록 -->
         <div class="modal-actions" v-else>
           <button type="button" class="confirm-btn" @click="closeModal">확인</button>
         </div>
       </div>
     </div>
-</template>
+  </template>
   
   <script setup>
   import { ref } from 'vue';
@@ -29,12 +34,13 @@
   
   function confirmDelete() {
     isDeleted.value = true;
-    emit('confirmDelete');
-    
+    emit('confirmDelete'); // 삭제 처리를 서버에 요청하거나 로직 처리
+  
+    // 5초 후에 모달 창을 자동으로 닫습니다.
     setTimeout(() => {
-      closeModal();
-      isDeleted.value = false;
-    }, 5000);
+      closeModal();  // 모달을 닫음
+      isDeleted.value = false;  // 초기 상태로 리셋 (다음에 모달이 열릴 때 "정말 삭제하시겠습니까?" 상태로 시작)
+    }, 5000); // 5000ms = 5초
   }
   </script>
   

--- a/wizbuddy_front/src/components/schedule/modal/ScheduleInfoModal.vue
+++ b/wizbuddy_front/src/components/schedule/modal/ScheduleInfoModal.vue
@@ -6,31 +6,43 @@
           <button @click="closeModal" class="close-btn">X</button>
         </div>
         <div class="modal-body">
-          <div v-for="(schedule, index) in schedules" :key="index" class="schedule-item">
-            <p>{{ getTimeSlot(schedule.type) }} {{ schedule.title }} </p>
+          <div v-for="(schedule, index) in flatSchedules" :key="index" class="schedule-item">
+            <p>{{ getTimeSlot(schedule.type) }}: {{ schedule.title }}</p>
             <button class="edit-btn">수정</button>
           </div>
         </div>
       </div>
     </div>
   </template>
-  
-  <script setup>
+
+<script setup>
+import { computed } from 'vue';
+
   const props = defineProps({
     isOpen: Boolean,
     selectedDate: Number,
     schedules: Array,
     currentMonth: String
   });
-  
+
   const emit = defineEmits(['close']);
-  
+
   function closeModal() {
     emit('close');
   }
-  
+
+  // Flatten the schedules to separate each name into its own entry
+  const flatSchedules = computed(() => {
+    return props.schedules.map(schedule => ({
+      title: schedule.title,
+      time: schedule.time,
+      type: schedule.type
+    }));
+  });
+
+  // Function to get time slot based on schedule type
   function getTimeSlot(type) {
-    switch(type) {
+    switch (type) {
       case 'fun':
         return '1T 09:00 ~ 14:00';
       case 'important':
@@ -42,7 +54,7 @@
     }
   }
   </script>
-  
+
   <style scoped>
   .modal-overlay {
     position: fixed;
@@ -56,7 +68,7 @@
     align-items: center;
     z-index: 1000;
   }
-  
+
   .modal-container {
     background-color: #fff;
     padding: 20px;
@@ -64,43 +76,42 @@
     width: 450px;
     box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
   }
-  
+
   .modal-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     margin-bottom: 10px;
   }
-  
+
   .modal-title {
     font-size: 20px;
     font-weight: bold;
   }
-  
+
   .close-btn {
     background-color: transparent;
     border: none;
     font-size: 20px;
     cursor: pointer;
   }
-  
+
   .schedule-item {
     margin-bottom: 10px;
     display: flex;
     justify-content: space-between;
   }
-  
+
   .edit-btn {
-    background-color: #4285F4;
+    background-color: #4285f4;
     color: white;
     padding: 5px 10px;
     border: none;
     border-radius: 5px;
     cursor: pointer;
   }
-  
+
   .edit-btn:hover {
     background-color: #357ae8;
   }
   </style>
-  

--- a/wizbuddy_front/src/components/schedule/modal/ScheduleInfoModal.vue
+++ b/wizbuddy_front/src/components/schedule/modal/ScheduleInfoModal.vue
@@ -1,0 +1,106 @@
+<template>
+    <div v-if="isOpen" class="modal-overlay" @click.self="closeModal">
+      <div class="modal-container">
+        <div class="modal-header">
+          <h3 class="modal-title">{{ currentMonth }} {{ selectedDate }}일</h3>
+          <button @click="closeModal" class="close-btn">X</button>
+        </div>
+        <div class="modal-body">
+          <div v-for="(schedule, index) in schedules" :key="index" class="schedule-item">
+            <p>{{ getTimeSlot(schedule.type) }} {{ schedule.title }} </p>
+            <button class="edit-btn">수정</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+  
+  <script setup>
+  const props = defineProps({
+    isOpen: Boolean,
+    selectedDate: Number,
+    schedules: Array,
+    currentMonth: String
+  });
+  
+  const emit = defineEmits(['close']);
+  
+  function closeModal() {
+    emit('close');
+  }
+  
+  function getTimeSlot(type) {
+    switch(type) {
+      case 'fun':
+        return '1T 09:00 ~ 14:00';
+      case 'important':
+        return '2T 14:00 ~ 17:00';
+      case 'personal':
+        return '3T 17:00 ~ 21:00';
+      default:
+        return '';
+    }
+  }
+  </script>
+  
+  <style scoped>
+  .modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+  }
+  
+  .modal-container {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 10px;
+    width: 450px;
+    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
+  }
+  
+  .modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+  }
+  
+  .modal-title {
+    font-size: 20px;
+    font-weight: bold;
+  }
+  
+  .close-btn {
+    background-color: transparent;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+  }
+  
+  .schedule-item {
+    margin-bottom: 10px;
+    display: flex;
+    justify-content: space-between;
+  }
+  
+  .edit-btn {
+    background-color: #4285F4;
+    color: white;
+    padding: 5px 10px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+  }
+  
+  .edit-btn:hover {
+    background-color: #357ae8;
+  }
+  </style>
+  

--- a/wizbuddy_front/src/components/schedule/modal/ScheduleInfoModalForDelete.vue
+++ b/wizbuddy_front/src/components/schedule/modal/ScheduleInfoModalForDelete.vue
@@ -1,0 +1,82 @@
+<template>
+  <div v-if="isOpen" class="modal-overlay" @click.self="closeModal">
+    <div class="modal-container">
+      <h3 class="modal-title">{{ currentMonth }} {{ selectedDate }}일 스케줄</h3>
+      <ul>
+        <li v-for="schedule in schedules" :key="schedule.title">
+          {{ schedule.time }}: {{ schedule.title }}
+          <button @click="requestDelete(schedule)">삭제</button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { defineEmits } from 'vue';
+
+const props = defineProps({
+  isOpen: Boolean,
+  selectedDate: Number,
+  schedules: Array,
+  currentMonth: String
+});
+
+const emit = defineEmits(['close', 'deleteRequest']);
+
+function closeModal() {
+  emit('close');
+}
+
+function requestDelete(schedule) {
+  emit('deleteRequest', schedule);
+}
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-container {
+  background-color: #fff;
+  padding: 30px;
+  border-radius: 10px;
+  width: 400px;
+  box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  margin-bottom: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+button {
+  background-color: #f44336;
+  color: white;
+  padding: 5px 10px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #d32f2f;
+}
+</style>


### PR DESCRIPTION
---
name: 기능 개발 이슈
about: 만든 기능 상세히 설명하자
title: '스케줄 - 단 건 조회 (수정으로 이어질 예정), 삭제 화면, 직원 등록 화면 구현'
labels: enhancement

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [x] 기능 수정
- [ ] 버그 픽스

메인 화면에서 스케줄 조회 시 조회가 가능하고, 수정으로 이동하기 이전 modal 창을 띄워 한 번에 할 수 있게 만들어 봤고,
삭제 버튼이나 직원 등록 버튼 시 해당 uri로 라우터됩니다.

삭제를 할 때는 스케줄을 클릭하고, 직원 등록 시에는 날짜를 클릭하여 삭제, 등록을 할 수 있게 하려고 구현해봤습니다.